### PR TITLE
Fix online_mod.js for FanSerials and WebOS

### DIFF
--- a/online_mod.js
+++ b/online_mod.js
@@ -11948,7 +11948,7 @@
         search: false,
         kp: true,
         imdb: false,
-        disabled: disable_dbg && !isAndroid
+        disabled: disable_dbg && !(isAndroid || Lampa.Platform.is('webos'))
       }, {
         name: 'videoseed',
         title: 'VideoSeed',
@@ -14725,3 +14725,4 @@
     });
 
 })();
+


### PR DESCRIPTION
Hi!
Please add this fix to the main repository — it enables the use of the FanSerials source on WebOS TVs.
Tested on my LG G5, the source and content are displayed and working.